### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 A golang preprocessor for generating template instantiations of types and functions
 
 ### Install
-
-got get -v github.com/redefiance/gotemplate
+```
+go get -u github.com/redefiance/gotemplate
+```
 
 ### Example
 
 Create a .go file within your project directory, e.g. `CircularBuffer.go`:
 
-```
+```go
 // +gotemplate
 
 package main
@@ -44,7 +45,7 @@ Type and function names must end with `_T`, method names must not.
 
 Now, you can use the new type in another file:
 
-```
+```go
 var buf = newCircularBuffer_uint64(10)
 ```
 


### PR DESCRIPTION
I've also specified the language in the code so it'll get syntax highlighted.
